### PR TITLE
Patch to resolve SEGV error when loading file list of different sizes.

### DIFF
--- a/cinelerra-5.1/cinelerra/file.C
+++ b/cinelerra-5.1/cinelerra/file.C
@@ -591,6 +591,17 @@ int File::open_file(Preferences *preferences,
 	}
 
 
+// If file type is a list verify that all files match in dimensions.
+// Should be done only after the file open function has been performed
+// Reason: although this function checks if file exists or not but
+// it has no way of relaying this information back and if this function
+// is called before open_file the program may accidently interpret file
+// not found as file size don't match
+	if( !file->verify_file_list() ) {
+		delete file;  file = 0;
+		return FILE_SIZE_DONT_MATCH;
+	}
+
 
 // Set extra writing parameters to mandatory settings.
 	if( wr ) {

--- a/cinelerra-5.1/cinelerra/file.inc
+++ b/cinelerra-5.1/cinelerra/file.inc
@@ -53,6 +53,7 @@
 #define FILE_NOT_FOUND 1
 #define FILE_UNRECOGNIZED_CODEC 2
 #define FILE_IS_XML 3
+#define FILE_SIZE_DONT_MATCH 4
 
 // Numeric codes for each file format
 // They're stored in XML files, so they have to be fixed.

--- a/cinelerra-5.1/cinelerra/filebase.h
+++ b/cinelerra-5.1/cinelerra/filebase.h
@@ -132,6 +132,10 @@ public:
 		int channel,
 		int64_t len);
 	void allocate_history(int len);
+// thie function will be used to verify if all files in a given
+// list are of same size or not. Each list type object should 
+// override this method with its own definition.
+        virtual int verify_file_list() { return 1; }
 
 // For static functions to access it
 	Asset *asset;

--- a/cinelerra-5.1/cinelerra/filegif.C
+++ b/cinelerra-5.1/cinelerra/filegif.C
@@ -32,6 +32,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <string.h>
+#include <ctype.h>
 
 FileGIF::FileGIF(Asset *asset, File *file)
  : FileBase(asset, file)

--- a/cinelerra-5.1/cinelerra/filegif.h
+++ b/cinelerra-5.1/cinelerra/filegif.h
@@ -81,6 +81,8 @@ public:
 	int read_frame(VFrame *output, char *path);
 	int write_frame(VFrame *frame, VFrame *data, FrameWriterUnit *unit);
 	FrameWriterUnit* new_writer_unit(FrameWriter *writer);
+// Need to override this method from FILEBASE class
+	int verify_file_list();
 };
 
 class GIFUnit : public FrameWriterUnit

--- a/cinelerra-5.1/cinelerra/mwindow.C
+++ b/cinelerra-5.1/cinelerra/mwindow.C
@@ -1932,6 +1932,14 @@ if(debug) printf("MWindow::load_filenames %d\n", __LINE__);
 			result = 0;
 			break;
 
+// File is a list and size of listed files don't match
+		case FILE_SIZE_DONT_MATCH: {
+			eprintf(_("File sizes don't match"));
+			sprintf(string, _("File sizes don't match"));
+			gui->show_message(string, theme->message_error);
+			gui->update_default_message();
+			break; }
+
 // File not found
 		case FILE_NOT_FOUND:
 			sprintf(string, _("Failed to open %s"), new_asset->path);


### PR DESCRIPTION
Created a new virtual function in FILEBASE class that should be overridden in every list type class as each file type (e.g. jpg, gif, bmp etc.) will have different headers. The overide function should follow these general principles:
1. Read the filelist if available.
2. Open each valid entry of the list file and read header for width / height information
3. Should store this information for subsequent comparisons if first instance or make comparison if not.
4. In case of failure should return 0 value or a value of 1 if all files were found to be of same size.